### PR TITLE
Changes to the constructors, additional getter and setter and minor fixes

### DIFF
--- a/examples/custom_parser_musa/musa_parser.cpp
+++ b/examples/custom_parser_musa/musa_parser.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <sstream>
+#include <algorithm>
 
 #include "musa_parser.hpp"
 

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -650,8 +650,8 @@ void Numa::SetSize(long long _size) { size = _size;}
 
 long long Memory::GetSize() {return size;}
 void Memory::SetSize(long long _size) {size = _size;}
-bool Memory::IsVolatile() {return is_volatile;}
-void Memory::SetVolatile(bool _is_volatile) {is_volatile = _is_volatile;}
+bool Memory::GetIsVolatile() {return is_volatile;}
+void Memory::SetIsVolatile(bool _is_volatile) {is_volatile = _is_volatile;}
 
 string Cache::GetCacheName(){return cache_type;}
 void Cache::SetCacheName(string _name) { cache_type = _name;}

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -716,12 +716,12 @@ Cache::Cache(int _id, int  _cache_level, long long _cache_size, int _associativi
 Cache::Cache(Component * parent, int _id, string _cache_type, long long _cache_size, int _associativity, int _cache_line_size): Component(parent, _id, "Cache", SYS_SAGE_COMPONENT_CACHE), cache_type(_cache_type), cache_size(_cache_size), cache_associativity_ways(_associativity), cache_line_size(_cache_line_size){}
 Cache::Cache(Component * parent, int _id, int _cache_level, long long _cache_size, int _associativity, int _cache_line_size): Cache(parent, _id, to_string(_cache_level), _cache_size, _associativity, -1){}
 
-Subdivision::Subdivision(Component * parent, int _id, string _name, int _componentType, int _subdivisionType): Component(parent, _id, _name, _componentType), type(_subdivisionType)
+Subdivision::Subdivision(Component * parent, int _id, string _name, int _componentType): Component(parent, _id, _name, _componentType)
 {
     //if(_componentType != SYS_SAGE_COMPONENT_SUBDIVISION && componentType != SYS_SAGE_COMPONENT_NUMA)
         //TODO solve this -- this should not happen
 }
-Subdivision::Subdivision(int _id, string _name, int _componentType, int _subdivisionType): Component(_id, _name, _componentType), type(_subdivisionType)
+Subdivision::Subdivision(int _id, string _name, int _componentType): Component(_id, _name, _componentType)
 {
     //if(_componentType != SYS_SAGE_COMPONENT_SUBDIVISION && componentType != SYS_SAGE_COMPONENT_NUMA)
         //TODO solve this -- this should not happen

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -700,7 +700,9 @@ Node::Node(int _id, string _name):Component(_id, _name, SYS_SAGE_COMPONENT_NODE)
 Node::Node(Component * parent, int _id, string _name):Component(parent, _id, _name, SYS_SAGE_COMPONENT_NODE){}
 
 Memory::Memory():Component(0, "Memory", SYS_SAGE_COMPONENT_MEMORY){}
-Memory::Memory(Component * parent, int _id, string _name, long long _size):Component(parent, _id, _name, SYS_SAGE_COMPONENT_MEMORY), size(_size){}
+//Memory::Memory(Component * parent, int _id, string _name, long long _size):Component(parent, _id, _name, SYS_SAGE_COMPONENT_MEMORY), size(_size){}
+Memory::Memory(Component * parent, int _id, string _name, long long _size, bool _is_volatile):Component(parent, _id, _name, SYS_SAGE_COMPONENT_MEMORY), size(_size), is_volatile(_is_volatile){}
+
 
 Storage::Storage():Component(0, "Storage", SYS_SAGE_COMPONENT_STORAGE){}
 Storage::Storage(Component * parent):Component(parent, 0, "Storage", SYS_SAGE_COMPONENT_STORAGE){}

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -650,6 +650,8 @@ void Numa::SetSize(long long _size) { size = _size;}
 
 long long Memory::GetSize() {return size;}
 void Memory::SetSize(long long _size) {size = _size;}
+bool Memory::IsVolatile() {return is_volatile;}
+void Memory::SetVolatile(bool _is_volatile) {is_volatile = _is_volatile;}
 
 string Cache::GetCacheName(){return cache_type;}
 void Cache::SetCacheName(string _name) { cache_type = _name;}
@@ -699,27 +701,27 @@ Topology::Topology():Component(0, "sys-sage Topology", SYS_SAGE_COMPONENT_TOPOLO
 Node::Node(int _id, string _name):Component(_id, _name, SYS_SAGE_COMPONENT_NODE){}
 Node::Node(Component * parent, int _id, string _name):Component(parent, _id, _name, SYS_SAGE_COMPONENT_NODE){}
 
-Memory::Memory():Component(0, "Memory", SYS_SAGE_COMPONENT_MEMORY){}
+Memory::Memory(long long _size, bool _is_volatile):Component(0, "Memory", SYS_SAGE_COMPONENT_MEMORY), size(_size), is_volatile(_is_volatile){}
 //Memory::Memory(Component * parent, int _id, string _name, long long _size):Component(parent, _id, _name, SYS_SAGE_COMPONENT_MEMORY), size(_size){}
 Memory::Memory(Component * parent, int _id, string _name, long long _size, bool _is_volatile):Component(parent, _id, _name, SYS_SAGE_COMPONENT_MEMORY), size(_size), is_volatile(_is_volatile){}
 
 
-Storage::Storage():Component(0, "Storage", SYS_SAGE_COMPONENT_STORAGE){}
-Storage::Storage(Component * parent):Component(parent, 0, "Storage", SYS_SAGE_COMPONENT_STORAGE){}
+Storage::Storage(long long _size):Component(0, "Storage", SYS_SAGE_COMPONENT_STORAGE), size(_size){}
+Storage::Storage(Component * parent, long long _size):Component(parent, 0, "Storage", SYS_SAGE_COMPONENT_STORAGE), size(_size){}
 
-Chip::Chip(int _id, string _name, int _type):Component(_id, _name, SYS_SAGE_COMPONENT_CHIP), type(_type) {}
-Chip::Chip(Component * parent, int _id, string _name, int _type):Component(parent, _id, _name, SYS_SAGE_COMPONENT_CHIP), type(_type){}
+Chip::Chip(int _id, string _name, int _type, string _vendor, string _model):Component(_id, _name, SYS_SAGE_COMPONENT_CHIP), type(_type), vendor(_vendor), model(_model) {}
+Chip::Chip(Component * parent, int _id, string _name, int _type, string _vendor, string _model):Component(parent, _id, _name, SYS_SAGE_COMPONENT_CHIP), type(_type), vendor(_vendor), model(_model){}
 
 Cache::Cache(int _id, int  _cache_level, long long _cache_size, int _associativity, int _cache_line_size): Component(_id, "Cache", SYS_SAGE_COMPONENT_CACHE), cache_type(to_string(_cache_level)), cache_size(_cache_size), cache_associativity_ways(_associativity), cache_line_size(_cache_line_size){}
 Cache::Cache(Component * parent, int _id, string _cache_type, long long _cache_size, int _associativity, int _cache_line_size): Component(parent, _id, "Cache", SYS_SAGE_COMPONENT_CACHE), cache_type(_cache_type), cache_size(_cache_size), cache_associativity_ways(_associativity), cache_line_size(_cache_line_size){}
 Cache::Cache(Component * parent, int _id, int _cache_level, long long _cache_size, int _associativity, int _cache_line_size): Cache(parent, _id, to_string(_cache_level), _cache_size, _associativity, -1){}
 
-Subdivision::Subdivision(Component * parent, int _id, string _name, int _componentType): Component(parent, _id, _name, _componentType)
+Subdivision::Subdivision(Component * parent, int _id, string _name, int _componentType, int _subdivisionType): Component(parent, _id, _name, _componentType), type(_subdivisionType)
 {
     //if(_componentType != SYS_SAGE_COMPONENT_SUBDIVISION && componentType != SYS_SAGE_COMPONENT_NUMA)
         //TODO solve this -- this should not happen
 }
-Subdivision::Subdivision(int _id, string _name, int _componentType): Component(_id, _name, _componentType)
+Subdivision::Subdivision(int _id, string _name, int _componentType, int _subdivisionType): Component(_id, _name, _componentType), type(_subdivisionType)
 {
     //if(_componentType != SYS_SAGE_COMPONENT_SUBDIVISION && componentType != SYS_SAGE_COMPONENT_NUMA)
         //TODO solve this -- this should not happen

--- a/src/Component.hpp
+++ b/src/Component.hpp
@@ -673,8 +673,10 @@ public:
     @param _id = 0
     @param _name = name, default "Memory"
     @param componentType=>SYS_SAGE_COMPONENT_MEMORY
+    @param _size = size/capacity of the memory element, default -1
+    @param is_volatile = true if the memory is volatile, default false
     */
-    Memory(Component * parent, int id = 0, string _name = "Memory", long long _size = -1);
+    Memory(Component * parent, int id = 0, string _name = "Memory", long long _size = -1, bool is_volatile = false);
     /**
     * @private
     * Use Delete() or DeleteSubtree() for deleting and deallocating the components. 

--- a/src/Component.hpp
+++ b/src/Component.hpp
@@ -1010,18 +1010,16 @@ public:
     @param _id = id, default 0
     @param _name = name, default "Subdivision"
     @param _componentType, componentType, default SYS_SAGE_COMPONENT_SUBDIVISION. If componentType is not SYS_SAGE_COMPONENT_SUBDIVISION or SYS_SAGE_COMPONENT_NUMA, it is set to SYS_SAGE_COMPONENT_SUBDIVISION as default option.
-    @param _subdivisionType = type, default 0
     */
-    Subdivision(int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION, int _subdivisionType = 0);
+    Subdivision(int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION);
     /**
     Subdivision constructor with insertion into the Component Tree as the parent 's child (as long as parent is an existing Component). Sets:
     @param parent = the parent 
     @param _id = id, default 0
     @param _name = name, default "Subdivision"
     @param _componentType, componentType, default SYS_SAGE_COMPONENT_SUBDIVISION. If componentType is not SYS_SAGE_COMPONENT_SUBDIVISION or SYS_SAGE_COMPONENT_NUMA, it is set to SYS_SAGE_COMPONENT_SUBDIVISION as default option.
-    @param _subdivisionType = type, default 0
     */
-    Subdivision(Component * parent, int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION, int _subdivisionType = 0);
+    Subdivision(Component * parent, int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION);
     /**
     * @private
     * Use Delete() or DeleteSubtree() for deleting and deallocating the components. 

--- a/src/Component.hpp
+++ b/src/Component.hpp
@@ -2,6 +2,7 @@
 #define COMPONENT
 
 #include <iostream>
+#include <type_traits>
 #include <vector>
 #include <map>
 #include <set>
@@ -665,8 +666,10 @@ public:
     @param _id = 0
     @param _name = "Memory"
     @param componentType=>SYS_SAGE_COMPONENT_MEMORY
+    @param _size = size/capacity of the memory element, default -1
+    @param is_volatile = true if the memory is volatile, default false
     */
-    Memory();
+    Memory(long long _size = -1, bool is_volatile = false);
     /**
     Memory constructor with insertion into the Component Tree as the parent 's child (as long as parent is an existing Component). Sets:
     @param parent = the parent 
@@ -693,6 +696,17 @@ public:
      * @param _size = size
     */
     void SetSize(long long _size);
+    /**
+     * Retrieves if the memory element is volatile
+     * @return is_volatile  
+     * 
+     */
+    bool IsVolatile();
+    /**
+     * Sets if the memory element is volatile
+     * @param _is_volatile = update is_volatile
+     */
+    void SetVolatile(bool _is_volatile);
     /**
     @private
     !!Should normally not be used!! Helper function of XML dump generation.
@@ -723,16 +737,18 @@ public:
     @param _id = 0
     @param _name = "Storage"
     @param componentType=>SYS_SAGE_COMPONENT_STORAGE
+    @param _size = size/capacity of the storage device, default -1
     */
-    Storage();
+    Storage(long long _size = -1);
     /**
     Storage constructor with insertion into the Component Tree as the parent 's child (as long as parent is an existing Component). Sets:
     @param parent = the parent 
     @param _id = 0
     @param _name = "Storage"
     @param componentType=>SYS_SAGE_COMPONENT_STORAGE
+    @param _size = size/capacity of the storage device, default -1
     */
-    Storage(Component * parent);
+    Storage(Component * parent, long long _size = -1);
     /**
     * @private
     * Use Delete() or DeleteSubtree() for deleting and deallocating the components. 
@@ -771,8 +787,10 @@ public:
     @param _name = name, default "Chip"
     @param _type = chip type, default SYS_SAGE_CHIP_TYPE_NONE. Defines which chip we are describing. The options are: SYS_SAGE_CHIP_TYPE_NONE (default/generic), SYS_SAGE_CHIP_TYPE_CPU, SYS_SAGE_CHIP_TYPE_CPU_SOCKET, SYS_SAGE_CHIP_TYPE_GPU.
     @param componentType=>SYS_SAGE_COMPONENT_CHIP
+    @param _vendor = name of the vendor, default ""
+    @param _model = model name, default ""
     */
-    Chip(int _id = 0, string _name = "Chip", int _type = SYS_SAGE_CHIP_TYPE_NONE);
+    Chip(int _id = 0, string _name = "Chip", int _type = SYS_SAGE_CHIP_TYPE_NONE, string _vendor = "", string _model = "");
     /**
     Chip constructor with insertion into the Component Tree as the parent 's child (as long as parent is an existing Component). Sets:
     @param parent = the parent 
@@ -780,8 +798,10 @@ public:
     @param _name = name, default "Chip"
     @param _type = chip type, default SYS_SAGE_CHIP_TYPE_NONE. Defines which chip we are describing. The options are: SYS_SAGE_CHIP_TYPE_NONE (default/generic), SYS_SAGE_CHIP_TYPE_CPU, SYS_SAGE_CHIP_TYPE_CPU_SOCKET, SYS_SAGE_CHIP_TYPE_GPU.
     @param componentType=>SYS_SAGE_COMPONENT_CHIP
+    @param _vendor = name of the vendor, default ""
+    @param _model = model name, default ""
     */
-    Chip(Component * parent, int _id = 0, string _name = "Chip", int _type = SYS_SAGE_CHIP_TYPE_NONE);
+    Chip(Component * parent, int _id = 0, string _name = "Chip", int _type = SYS_SAGE_CHIP_TYPE_NONE, string _vendor = "", string _model = "");
     /**
     * @private
     * Use Delete() or DeleteSubtree() for deleting and deallocating the components. 
@@ -990,16 +1010,18 @@ public:
     @param _id = id, default 0
     @param _name = name, default "Subdivision"
     @param _componentType, componentType, default SYS_SAGE_COMPONENT_SUBDIVISION. If componentType is not SYS_SAGE_COMPONENT_SUBDIVISION or SYS_SAGE_COMPONENT_NUMA, it is set to SYS_SAGE_COMPONENT_SUBDIVISION as default option.
+    @param _subdivisionType = type, default 0
     */
-    Subdivision(int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION);
+    Subdivision(int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION, int _subdivisionType = 0);
     /**
     Subdivision constructor with insertion into the Component Tree as the parent 's child (as long as parent is an existing Component). Sets:
     @param parent = the parent 
     @param _id = id, default 0
     @param _name = name, default "Subdivision"
     @param _componentType, componentType, default SYS_SAGE_COMPONENT_SUBDIVISION. If componentType is not SYS_SAGE_COMPONENT_SUBDIVISION or SYS_SAGE_COMPONENT_NUMA, it is set to SYS_SAGE_COMPONENT_SUBDIVISION as default option.
+    @param _subdivisionType = type, default 0
     */
-    Subdivision(Component * parent, int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION);
+    Subdivision(Component * parent, int _id = 0, string _name = "Subdivision", int _componentType = SYS_SAGE_COMPONENT_SUBDIVISION, int _subdivisionType = 0);
     /**
     * @private
     * Use Delete() or DeleteSubtree() for deleting and deallocating the components. 

--- a/src/Component.hpp
+++ b/src/Component.hpp
@@ -701,12 +701,12 @@ public:
      * @return is_volatile  
      * 
      */
-    bool IsVolatile();
+    bool GetIsVolatile();
     /**
      * Sets if the memory element is volatile
      * @param _is_volatile = update is_volatile
      */
-    void SetVolatile(bool _is_volatile);
+    void SetIsVolatile(bool _is_volatile);
     /**
     @private
     !!Should normally not be used!! Helper function of XML dump generation.

--- a/src/parsers/mt4g.cpp
+++ b/src/parsers/mt4g.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <tuple>
 #include <string>
+#include <algorithm>
 
 int parseMt4gTopo(Node* parent, string dataSourcePath, int gpuId, string delim)
 {

--- a/src/xml_dump.cpp
+++ b/src/xml_dump.cpp
@@ -250,12 +250,12 @@ int exportToXml(Component* root, string path, std::function<int(string,void*,str
     for(Component* cPtr : components)
     {
         vector<DataPath*>* dpList = cPtr->GetDataPaths(SYS_SAGE_DATAPATH_INCOMING);
-        vector<DataPath*> printed_dp;
+        set<DataPath*> printed_dp;
 
         for(DataPath* dpPtr : *dpList)
         {
             //check if previously processed
-            if (std::find(printed_dp.begin(), printed_dp.end(), dpPtr) == printed_dp.end())
+            if (printed_dp.find(dpPtr) == printed_dp.end())
             {
                 xmlNodePtr dp_n = xmlNewNode(NULL, BAD_CAST "datapath");
                 std::ostringstream src_addr;
@@ -272,7 +272,7 @@ int exportToXml(Component* root, string path, std::function<int(string,void*,str
 
                 print_attrib(dpPtr->attrib, dp_n);
 
-                printed_dp.push_back(dpPtr);
+                printed_dp.insert(dpPtr);
             }
         }
     }


### PR DESCRIPTION
I modified some of the Constructors of the Component-Subclasses. A few parameters where missing, so with the modifications is now possible to assign the values to the attributes. Before it was only possible by using Setters after object-creation.
Speaking of Setters for the Memory Component there is the attribute "is_volatile" and now the attributes value can be assigned via the constructor or with the respective setter.
Additionally there were some errors occurring while compiling that are now fixed by minor adjustments.