### PR TITLE
Fix cmake pkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,23 +18,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 #################### DEPENDENCIES ####################
 ######################################################
 # libxml2
-find_package(LibXml2 REQUIRED) # Use pkg-config via the LibXml2 find-module
-execute_process(COMMAND xml2-config --cflags OUTPUT_VARIABLE LIBXML_F OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND xml2-config --libs OUTPUT_VARIABLE LIBXML_L OUTPUT_STRIP_TRAILING_WHITESPACE)
-include_directories(${LIBXML_F})
-link_libraries(${LIBXML_L})
-include_directories(${LIBXML2_INCLUDE_DIR})
-include_directories(${LIBXML2_INCLUDE_DIRS})
-link_libraries(${LIBXML2_LIBRARY})
-link_libraries(${LIBXML2_LIBRARIES})
+find_package(LibXml2 REQUIRED)
 
 # Find nlohmann_json package
 find_package(nlohmann_json 3.10 REQUIRED)
 
 if(NVIDIA_MIG)
   find_package(CUDAToolkit 10.0 REQUIRED)
-  include_directories(CUDA::nvml)
-  link_libraries(CUDA::nvml)
 endif()
 
 if(DATA_SOURCES OR DS_HWLOC)
@@ -103,8 +93,6 @@ endif()
 
 if(PAPI)
   find_package(PAPI REQUIRED)
-  include_directories(${PAPI_INCLUDE_DIRS})
-  link_libraries(${PAPI_LIBRARIES})
 endif()
 
 # Top-level build just includes subdirectories.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(nlohmann_json 3.10 REQUIRED)
 
 if(NVIDIA_MIG)
   find_package(CUDAToolkit 10.0 REQUIRED)
+  include_directories(CUDA::nvml)
+  link_libraries(CUDA::nvml)
 endif()
 
 if(DATA_SOURCES OR DS_HWLOC)
@@ -93,6 +95,8 @@ endif()
 
 if(PAPI)
   find_package(PAPI REQUIRED)
+  include_directories(${PAPI_INCLUDE_DIRS})
+  link_libraries(${PAPI_LIBRARIES})
 endif()
 
 # Top-level build just includes subdirectories.

--- a/pkg/sys-sage-config.cmake.in
+++ b/pkg/sys-sage-config.cmake.in
@@ -1,9 +1,9 @@
-
-
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+
 find_dependency(LibXml2)
+find_dependency(nlohmann_json)
 #TODO: the conditional options NVIDIA_MIG, DS_HWLOC will have to be set at the user's side (or the libraries present..) -- this should be included automatically if the options are set when building/installing
 if(NVIDIA_MIG)
   find_dependency(CUDAToolkit 10.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,16 +131,6 @@ endif()
 
     add_library(sys-sage SHARED ${SOURCES} ${HEADERS})
 
-    if(NVIDIA_MIG)
-        target_include_directories(sys-sage PUBLIC CUDA::nvml)
-        target_link_libraries(sys-sage PUBLIC CUDA::nvml)
-    endif()
-
-    if(PAPI)
-        target_include_directories(sys-sage PUBLIC ${PAPI_INCLUDE_DIRS})
-        target_link_libraries(sys-sage PUBLIC ${PAPI_LIBRARIES})
-    endif()
-
     # For Quantum Systems
     if(QDMI)
         target_link_libraries(sys-sage PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,16 @@ endif()
 
     add_library(sys-sage SHARED ${SOURCES} ${HEADERS})
 
+    if(NVIDIA_MIG)
+        target_include_directories(sys-sage PUBLIC CUDA::nvml)
+        target_link_libraries(sys-sage PUBLIC CUDA::nvml)
+    endif()
+
+    if(PAPI)
+        target_include_directories(sys-sage PUBLIC ${PAPI_INCLUDE_DIRS})
+        target_link_libraries(sys-sage PUBLIC ${PAPI_LIBRARIES})
+    endif()
+
     # For Quantum Systems
     if(QDMI)
         target_link_libraries(sys-sage PUBLIC
@@ -139,6 +149,7 @@ endif()
         )
     endif()
 
+    target_link_libraries(sys-sage PUBLIC LibXml2::LibXml2)
     target_link_libraries(sys-sage PUBLIC nlohmann_json::nlohmann_json)
 
     target_include_directories(sys-sage PUBLIC  
@@ -157,7 +168,7 @@ endif()
     install(
         EXPORT sys-sage-targets
         FILE sys-sage-targets.cmake
-        DESTINATION lib/cmake/syssage
+        DESTINATION lib/cmake/sys-sage
         NAMESPACE syssage::
     )
     install(DIRECTORY "."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ if(PY_SYS_SAGE)
     pybind11_add_module(sys_sage MODULE ${PY_BINDS}/sys-sage-bindings.cpp ${SOURCES} ${HEADERS})
     target_link_libraries(sys_sage PUBLIC ${PYTHON_LIBRARIES} pybind11::module)
     target_link_libraries(sys_sage PUBLIC nlohmann_json::nlohmann_json)
+    target_link_libraries(sys_sage PUBLIC LibXml2::LibXml2)
     install(
         TARGETS sys_sage
         LIBRARY DESTINATION ${PYTHON_SITE}       # For Unix-like systems


### PR DESCRIPTION
This PR is about making necessary fixes to the CMake files and pkg file to be able to use sys-sage through CMake. This is needed as a prerequisite for seperating the Python bindings into a seperate cmake file.

If you wonder why I've made some changes to the libxml2 include and library dirs, it's because I need to propegate the libxml2 dependency to the user, e.g. make it PUBLIC. However, the "global" `include_directories` command don't have a way to specify that this should be public, as opposed to the "target-specific" `target_include_directories`. So I've changed the libxml2 dependency to be target-specifc so that I can make it public.

I could have also instead defined a variable for sys-sage such as `sys-sage-INCLUDE_DIRS` and `sys-sage-LIBRARY_DIRS`, so that the user could do something like `target_include_directories(foo PRIVATE sys-sage-INCLUDE_DIRS)`, but I think this is too much of a hassle now.

The described problem might also apply to other dependencies like PAPI, but for now let's make the bare-minum for this PR so that you can see what is needed.