### PR TITLE
Rework cmake files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr -DPROC_CPUINFO=ON -DDS_HWLOC=ON -DDS_NUMA=ON -DPAPI=ON -DPY_SYS_SAGE=ON -DTEST=ON -GNinja ${{ inputs.flags }}
       - name: Build
-        run: cmake --build build --target all install test
+        run: sudo cmake --build build --target all install test
       - name: Cpp tests
         run: ./build/test/test
       - name: Python tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Get dependecies
         run: sudo apt-get install -yy libxml2-dev nlohmann-json3-dev python3-dev pybind11-dev libpapi-dev hwloc libhwloc-common libhwloc-dev
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr -DPROC_CPUINFO=ON -DDS_HWLOC=ON -DDS_NUMA=ON -DPAPI=ON -DPY_SYS_SAGE=ON -DTEST=ON -GNinja ${{ inputs.flags }}
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=inst-dir -DPROC_CPUINFO=ON -DDS_HWLOC=ON -DDS_NUMA=ON -DPAPI=ON -DPY_SYS_SAGE=ON -DTEST=ON -GNinja ${{ inputs.flags }}
       - name: Build
-        run: sudo cmake --build build --target all install test
+        run: cmake --build build --target all install test
       - name: Cpp tests
         run: ./build/test/test
       - name: Python tests
         run:  |
-              python3 test/topology.py
-              python3 test/datapath.py
-              python3 test/relation.py
+              LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/inst-dir/lib PYTHONPATH=$(echo $(pwd)/inst-dir/lib/python*/site-packages) python3 test/topology.py
+              LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/inst-dir/lib PYTHONPATH=$(echo $(pwd)/inst-dir/lib/python*/site-packages) python3 test/datapath.py
+              LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/inst-dir/lib PYTHONPATH=$(echo $(pwd)/inst-dir/lib/python*/site-packages) python3 test/relation.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Get dependecies
         run: sudo apt-get install -yy libxml2-dev nlohmann-json3-dev python3-dev pybind11-dev libpapi-dev hwloc libhwloc-common libhwloc-dev
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=inst-dir -DPROC_CPUINFO=ON -DDS_HWLOC=ON -DDS_NUMA=ON -DPAPI=ON -DPY_SYS_SAGE=ON -DTEST=ON -GNinja ${{ inputs.flags }}
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr -DPROC_CPUINFO=ON -DDS_HWLOC=ON -DDS_NUMA=ON -DPAPI=ON -DPY_SYS_SAGE=ON -DTEST=ON -GNinja ${{ inputs.flags }}
       - name: Build
         run: cmake --build build --target all install test
       - name: Cpp tests
         run: ./build/test/test
       - name: Python tests
         run:  |
-              PYTHONPATH=$(echo ./inst-dir/lib/python*/site-packages) python3 test/topology.py
-              PYTHONPATH=$(echo ./inst-dir/lib/python*/site-packages) python3 test/datapath.py
-              PYTHONPATH=$(echo ./inst-dir/lib/python*/site-packages) python3 test/relation.py
+              python3 test/topology.py
+              python3 test/datapath.py
+              python3 test/relation.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,85 +1,33 @@
-cmake_policy(SET CMP0048 NEW)
 cmake_minimum_required(VERSION 3.22)
-
-set (CMAKE_CXX_STANDARD 20)
-set (CXX_STANDARD_REQUIRED ON)
-set (CMAKE_CXX_FLAGS " -Wall")
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0")
-    message(FATAL_ERROR "Insufficient gcc version (at least 8.0.0) set for example with CXX=/path/to/compiler cmake ....")
-  endif()
-endif()
-
-project(sys-sage VERSION 1.0.0 LANGUAGES C CXX )
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+project(sys-sage VERSION 1.1.0 LANGUAGES C CXX)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 ######################################################
-#################### DEPENDENCIES ####################
+####################### TARGET #######################
 ######################################################
-# libxml2
-find_package(LibXml2 REQUIRED)
 
-# Find nlohmann_json package
-find_package(nlohmann_json 3.10 REQUIRED)
+add_library(sys-sage SHARED)
 
-if(NVIDIA_MIG)
-  find_package(CUDAToolkit 10.0 REQUIRED)
-  include_directories(CUDA::nvml)
-  link_libraries(CUDA::nvml)
-endif()
+target_compile_features(sys-sage PUBLIC cxx_std_20)
+set_target_properties(sys-sage PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_options(sys-sage PRIVATE -Wall)
 
-if(DATA_SOURCES OR DS_HWLOC)
-  find_package(HWLOC REQUIRED)
-endif()
+######################################################
+####################### OPTIONS ######################
+######################################################
 
-if(PY_SYS_SAGE)
-  find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
-  find_package(pybind11 CONFIG REQUIRED)
-endif()
+option(INTEL_PQOS "Build with Intel L3 CAT support" OFF)
+option(NVIDIA_MIG "Build with NVIDIA MIG support" OFF)
+option(PROC_CPUINFO "Build with Linux proc/cpuinfo support" OFF)
+option(DATA_SOURCES "Build with all data sources" OFF)
+option(DS_HWLOC "Build with the hwloc data source" OFF)
+option(DS_MT4G "Build with the mt4g data source" OFF)
+option(DS_NUMA "Build with the caps-numa-benchmark data source" OFF)
+option(QDMI "Build with QDMI support" OFF)
+option(PAPI "Build with PAPI support" OFF)
+option(PY_SYS_SAGE "Build with Python bindings" OFF)
 
-if(QDMI)
-    # Find QDMI package
-    find_package(backends REQUIRED)
-    # Find QInfo package
-    find_package(qinfo REQUIRED)
-endif()
-
-if(DATA_SOURCES OR DS_NUMA)
-    find_package(numactl REQUIRED)
-endif()
-
-# Create and install package configuration and version files.
-include(CMakePackageConfigHelpers)
-configure_package_config_file(${sys-sage_SOURCE_DIR}/pkg/sys-sage-config.cmake.in
-                              ${sys-sage_BINARY_DIR}/pkg/sys-sage-config.cmake
-                              INSTALL_DESTINATION lib/cmake/sys-sage)
-#configure_package_config_file(${sys-sage_SOURCE_DIR}/pkg/sys-sage-config-version.cmake.in
-#                              ${sys-sage_BINARY_DIR}/pkg/sys-sage-config-version.cmake
-#                              INSTALL_DESTINATION lib/cmake/sys-sage)
-install(FILES ${sys-sage_BINARY_DIR}/pkg/sys-sage-config.cmake
-                #${sys-sage_BINARY_DIR}/pkg/sys-sage-config-version.cmake
-                DESTINATION lib/cmake/sys-sage)
-
-configure_file(${sys-sage_SOURCE_DIR}/pkg/sys-sage.pc.in
-                ${sys-sage_BINARY_DIR}/pkg/sys-sage.pc @ONLY)
-install(FILES ${sys-sage_BINARY_DIR}/pkg/sys-sage.pc
-         DESTINATION lib)
-
-
-
-###Options:
-option(INTEL_PQOS "Build and install functionality regarding Intel L3 CAT" OFF)
-option(NVIDIA_MIG "Build and install functionality regarding NVidia MIG(multi-instance GPU, ampere or newer)" OFF)
-option(PROC_CPUINFO "Build and install functionality regarding Linux cpuinfo" OFF)
-option(DATA_SOURCES "Build and install all data sources" OFF)
-option(DS_HWLOC "Build and install data source hwloc (Retrieves hwloc topology information)" OFF)
-option(DS_MT4G "Build and install data source mt4g (Compute and memory topology of NVidia GPUs)" OFF)
-option(DS_NUMA "Build and install data source caps-numa-benchmark" OFF)
-option(QDMI "Build with QDMI for Quantum Systems" OFF)
-option(PAPI "Build and install with performance metrics functionality using PAPI" OFF)
-
-set(SS_PAPI ${PAPI})
+set(SS_PAPI ${PAPI}) # for internal use in CXX source code
 
 option(TEST "Build tests" OFF)
 option(TEST_ASAN "Build tests with enabled address sanitizers" OFF)
@@ -93,13 +41,43 @@ if(DATA_SOURCES)
     set(DS_NUMA ON)
 endif()
 
-if(PAPI)
-  find_package(PAPI REQUIRED)
-  include_directories(${PAPI_INCLUDE_DIRS})
-  link_libraries(${PAPI_LIBRARIES})
+######################################################
+#################### DEPENDENCIES ####################
+######################################################
+
+find_package(LibXml2 REQUIRED)
+find_package(nlohmann_json 3.10 REQUIRED)
+
+if(NVIDIA_MIG)
+    find_package(CUDAToolkit 10.0 REQUIRED)
 endif()
 
-# Top-level build just includes subdirectories.
+if(DS_HWLOC)
+    find_package(HWLOC REQUIRED)
+endif()
+
+if(PY_SYS_SAGE)
+    set(PYBIND11_FINDPYTHON ON)
+    find_package(pybind11 CONFIG REQUIRED)
+endif()
+
+if(DS_NUMA)
+    find_package(numactl REQUIRED)
+endif()
+
+if(QDMI)
+    find_package(backends REQUIRED)
+    find_package(qinfo REQUIRED)
+endif()
+
+if(PAPI)
+    find_package(PAPI REQUIRED)
+endif()
+
+######################################################
+################### SUBDIRECTORIES ###################
+######################################################
+
 add_subdirectory(src)
 add_subdirectory(examples)
 add_subdirectory(data-sources)

--- a/data-sources/CMakeLists.txt
+++ b/data-sources/CMakeLists.txt
@@ -1,51 +1,52 @@
-
-
 ###### hwloc
 if(DS_HWLOC)
     message(STATUS "DS_HWLOC - hwloc data source")
-    find_package(OpenMP)
-    if (OPENMP_FOUND)
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-    endif()
 
     add_executable(hwloc-output hwloc-output.cpp)
-    target_include_directories(hwloc-output PUBLIC ${HWLOC_INCLUDE_DIRS})
+
+    target_include_directories(hwloc-output PRIVATE ${HWLOC_INCLUDE_DIRS})
     target_link_directories(hwloc-output PRIVATE ${HWLOC_LIBRARY_DIRS})
     target_link_libraries(hwloc-output PRIVATE ${HWLOC_LIBRARIES})
-    install(TARGETS hwloc-output DESTINATION bin)
+
+    find_package(OpenMP COMPONENTS CXX)
+    if(OpenMP_FOUND)
+        target_link_libraries(hwloc-output PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+
+    install(TARGETS hwloc-output DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 ###### numa
 if(DS_NUMA)
-    message(STATUS "DS_NUMA - cape-numa-benchmark data source")
+    message(STATUS "DS_NUMA - caps-numa-benchmark data source")
+
     add_executable(caps-numa-benchmark caps-numa-benchmark.cpp)
-    target_include_directories(caps-numa-benchmark PUBLIC ${NUMACTL_INCLUDE_DIRS})
-    target_link_libraries(caps-numa-benchmark ${NUMACTL_LIBRARIES})
-    install(TARGETS caps-numa-benchmark DESTINATION bin)
+
+    target_include_directories(caps-numa-benchmark PRIVATE ${NUMACTL_INCLUDE_DIRS})
+    target_link_directories(caps-numa-benchmark PRIVATE ${NUMACTL_LIB_DIR})
+    target_link_libraries(caps-numa-benchmark PRIVATE ${NUMACTL_LIBRARIES})
+
+    install(TARGETS caps-numa-benchmark DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 ###### mt4g
 if(DS_MT4G)
     message(STATUS "DS_MT4G - mt4g data source")
-    find_package(Git QUIET)
-    if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-        # Update submodules as needed
-        option(GIT_SUBMODULE "Check submodules during build" ON)
-        if(GIT_SUBMODULE)
-            message(STATUS "Submodule update")
-            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                            RESULT_VARIABLE GIT_SUBMOD_RESULT)
+
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/mt4g/CMakeLists.txt")
+        find_package(Git QUIET)
+        if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                RESULT_VARIABLE GIT_SUBMOD_RESULT
+            )
+
             if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-                message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+                message(FATAL_ERROR "'git submodule update --init --recursive' failed with exit code '${GIT_SUBMOD_RESULT}'")
             endif()
         endif()
     endif()
-    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/mt4g/CMakeLists.txt")
-        message(STATUS "Path ${PROJECT_SOURCE_DIR}/mt4g/CMakeLists.txt does not exist.")
-        message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
-    endif()
+
     add_subdirectory(mt4g)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,63 +1,96 @@
-
 link_libraries(sys-sage sys-sage)
 include_directories(../src)
 # include_directories(../src/external_interfaces)
 # include_directories(../src/pa)
 
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
+######################################################
+################## GENERAL EXAMPLES ##################
+######################################################
 
 add_executable(basic_usage basic_usage.cpp)
+target_link_libraries(basic_usage PRIVATE sys-sage)
+
 add_executable(custom_attributes custom_attributes.cpp)
+target_link_libraries(custom_attributes PRIVATE sys-sage)
+
 add_executable(mt4g-parser mt4g-parser.cpp)
+target_link_libraries(mt4g-parser PRIVATE sys-sage)
+
 add_executable(larger_topo larger_topo.cpp)
+target_link_libraries(larger_topo PRIVATE sys-sage)
+
 add_executable(sys-sage-benchmarking sys-sage-benchmarking.cpp)
+target_link_libraries(sys-sage-benchmarking PRIVATE sys-sage)
+
 add_executable(use_custom_parser custom_parser_musa/use_custom_parser.cpp custom_parser_musa/musa_parser.cpp custom_parser_musa/musa_parser.hpp)
+target_link_libraries(use_custom_parser PRIVATE sys-sage)
+
 add_executable(cccbenchplushwloc cccbenchplushwloc.cpp)
+target_link_libraries(cccbenchplushwloc PRIVATE sys-sage)
+
 add_executable(iqm-test iqm-test.cpp)
+target_link_libraries(iqm-test PRIVATE sys-sage)
+
 add_executable(xml_import xml_import.cpp)
-if (QDMI)
-    add_executable(qdmi-test qdmi-test.cpp)
-endif()
+target_link_libraries(xml_import PRIVATE sys-sage)
 
-if(SS_PAPI)
-    add_executable(papi_basics papi_basics.cpp)
-    add_executable(papi_multithreading papi_multithreading.cpp)
-    add_executable(papi_monitor_process papi_monitor_process.cpp)
-    add_executable(papi_migrate_cpus papi_migrate_cpus.cpp)
-endif()
-
-if(SS_PAPI AND PROC_CPUINFO)
-    add_executable(papi_greenscore papi_greenscore.cpp)
-endif()
-
-install(TARGETS basic_usage mt4g-parser custom_attributes larger_topo sys-sage-benchmarking use_custom_parser cccbenchplushwloc xml_import iqm-test DESTINATION bin/examples)
-install(DIRECTORY example_data DESTINATION bin/examples)
+######################################################
+############ BUILD-OPTION-SPECIFIC EXAMPLES ##########
+######################################################
 
 if(INTEL_PQOS)
     add_executable(matmul matmul.cpp)
-    set_source_files_properties(matmul.cpp PROPERTIES COMPILE_FLAGS -O3)
-    target_link_libraries(matmul hwloc pqos )
-    install(TARGETS matmul DESTINATION bin/examples)
-endif()
-
-if(PROC_CPUINFO)
-    add_executable(cpu-frequency cpu-frequency.cpp)
-    install(TARGETS cpu-frequency DESTINATION bin/examples)
+    target_compile_options(matmul PRIVATE -O3)
+    target_link_libraries(matmul PRIVATE
+        sys-sage
+        hwloc
+        pqos
+    )
 endif()
 
 if(NVIDIA_MIG)
     add_executable(nvidia-mig nvidia-mig.cpp)
-    install(TARGETS nvidia-mig DESTINATION bin/examples)
+    target_link_libraries(nvidia-mig PRIVATE sys-sage)
 endif()
 
-if (QDMI)
-    target_link_libraries(qdmi-test PRIVATE
-      qdmi
-      qinfo
-      )
+if(PROC_CPUINFO)
+    add_executable(cpu-frequency cpu-frequency.cpp)
+    target_link_libraries(cpu-frequency PRIVATE sys-sage)
 endif()
+
+if(PAPI)
+    add_executable(papi_basics papi_basics.cpp)
+    target_link_libraries(papi_basics PRIVATE sys-sage)
+
+    add_executable(papi_multithreading papi_multithreading.cpp)
+    target_link_libraries(papi_multithreading PRIVATE sys-sage)
+
+    add_executable(papi_monitor_process papi_monitor_process.cpp)
+    target_link_libraries(papi_monitor_process PRIVATE sys-sage)
+
+    add_executable(papi_migrate_cpus papi_migrate_cpus.cpp)
+    target_link_libraries(papi_migrate_cpus PRIVATE sys-sage)
+endif()
+
+if(PAPI AND PROC_CPUINFO)
+    add_executable(papi_greenscore papi_greenscore.cpp)
+    target_link_libraries(papi_greenscore PRIVATE sys-sage)
+endif()
+
+if(QDMI)
+    add_executable(qdmi-test qdmi-test.cpp)
+    target_link_libraries(qdmi-test PRIVATE
+        sys-sage
+        qdmi
+        qinfo
+    )
+endif()
+
+######################################################
+#################### INSTALLATION ####################
+######################################################
+
+include(GNUInstallDirs)
+
+install(TARGETS basic_usage mt4g-parser custom_attributes larger_topo sys-sage-benchmarking use_custom_parser cccbenchplushwloc xml_import iqm-test DESTINATION ${CMAKE_INSTALL_BINDIR}/examples)
+install(DIRECTORY example_data DESTINATION ${CMAKE_INSTALL_BINDIR}/examples)

--- a/pkg/sys-sage.pc.in
+++ b/pkg/sys-sage.pc.in
@@ -1,5 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,11 @@
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
+# header with #cmakedefine macros for build options
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/defines.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/defines.hpp)
 
-#defines.hpp header with #cmakedefine 
-configure_file(${PROJECT_SOURCE_DIR}/src/defines.hpp.in ${PROJECT_SOURCE_DIR}/src/defines.hpp)
+######################################################
+#################### SOURCE FILES ####################
+######################################################
 
-include_directories(external_interfaces)
-set(EXT_INTF "external_interfaces")
-set(PY_BINDS "python-bindings")
-
-set(SOURCES
+target_sources(sys-sage PRIVATE
     Component.cpp
     Thread.cpp
     Core.cpp
@@ -30,66 +27,70 @@ set(SOURCES
     xml_dump.cpp
     xml_load.cpp
     json_serialization.cpp
-    ${EXT_INTF}/intel_pqos.cpp
-    ${EXT_INTF}/proc_cpuinfo.cpp
-    ${EXT_INTF}/nvidia_mig.cpp
-    #${PY_BINDS}/sys-sage-bindings.cpp
     parsers/hwloc.cpp
     parsers/caps-numa-benchmark.cpp
     parsers/mt4g.cpp
     parsers/mt4g_v0_1.cpp
     parsers/cccbench.cpp
-    parsers/qdmi-parser.cpp
     parsers/iqm-parser.cpp
-    )
+)
 
-set(HEADERS
-    sys-sage.hpp
-    defines.hpp
-    enums.hpp
-    Component.hpp
-    Thread.hpp
-    Core.hpp
-    Cache.hpp
-    Subdivision.hpp
-    Numa.hpp
-    Chip.hpp
-    Memory.hpp
-    Storage.hpp
-    Node.hpp
-    QuantumBackend.hpp
-    Qubit.hpp
-    AtomSite.hpp
-    Topology.hpp
-    Relation.hpp
-    DataPath.hpp
-    QuantumGate.hpp
-    CouplingMap.hpp
-    attribute.hpp
-    xml_dump.hpp
-    xml_load.hpp
-    json_serialization.hpp
-    parsers/hwloc.hpp
-    parsers/caps-numa-benchmark.hpp
-    parsers/mt4g.hpp
-    parsers/cccbench.hpp
-    parsers/qdmi-parser.hpp
-    parsers/iqm-parser.hpp
-    )
-
-if(SS_PAPI)
-	list(APPEND SOURCES ${EXT_INTF}/ss_papi.cpp)
-	list(APPEND HEADERS ${EXT_INTF}/ss_papi.hpp)
+if(INTEL_PQOS)
+    target_sources(sys-sage PRIVATE external_interfaces/intel_pqos.cpp)
 endif()
 
-# add_library(sys-sage SHARED ${SOURCES} ${HEADERS})
+if(NVIDIA_MIG)
+    target_sources(sys-sage PRIVATE external_interfaces/nvidia_mig.cpp)
+endif()
+
+if(PROC_CPUINFO)
+    target_sources(sys-sage PRIVATE external_interfaces/proc_cpuinfo.cpp)
+endif()
+
+if(PAPI)
+    target_sources(sys-sage PRIVATE external_interfaces/ss_papi.cpp)
+endif()
+
+if(QDMI)
+    target_sources(sys-sage PRIVATE parsers/qdmi-parser.cpp)
+endif()
+
+######################################################
+################ INCLUDES & LINKING ##################
+######################################################
+
+include(GNUInstallDirs)
+
+target_include_directories(sys-sage PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(sys-sage PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(sys-sage PUBLIC LibXml2::LibXml2)
+
+if(NVIDIA_MIG)
+    target_link_libraries(sys-sage PUBLIC CUDA::nvml)
+endif()
+
+if(PAPI)
+    target_include_directories(sys-sage PUBLIC ${PAPI_INCLUDE_DIRS})
+    target_link_libraries(sys-sage PUBLIC ${PAPI_LIBRARIES})
+endif()
+
+if(QDMI)
+    target_link_libraries(sys-sage PUBLIC
+        backend_ibm
+        qdmi
+        qinfo
+    )
+endif()
+
+######################################################
+################### PYTHON BINDINGS ##################
+######################################################
 
 if(PY_SYS_SAGE)
-    # find_package(Python 3.13 COMPONENTS Interpreter Development REQUIRED)
-    link_directories(${PYTHON_LIBRARY_DIRS})
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    set(PYBIND11_FINDPYTHON ON)
-    # find_package(pybind11 CONFIG REQUIRED)
     # Get Python site-packages path
     execute_process(
         COMMAND "${Python_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_paths().get('purelib', ''))"
@@ -115,10 +116,9 @@ if(PY_SYS_SAGE)
     message(STATUS "PY_BINDS=${PY_BINDS}")
 
     # This builds a Python extension module (NOT a regular .so/.dylib)
-    pybind11_add_module(sys_sage MODULE ${PY_BINDS}/sys-sage-bindings.cpp ${SOURCES} ${HEADERS})
-    target_link_libraries(sys_sage PUBLIC ${PYTHON_LIBRARIES} pybind11::module)
-    target_link_libraries(sys_sage PUBLIC nlohmann_json::nlohmann_json)
-    target_link_libraries(sys_sage PUBLIC LibXml2::LibXml2)
+    pybind11_add_module(sys_sage MODULE python-bindings/sys-sage-bindings.cpp)
+    target_link_libraries(sys_sage PRIVATE sys-sage)
+
     install(
         TARGETS sys_sage
         LIBRARY DESTINATION ${PYTHON_SITE}       # For Unix-like systems
@@ -127,53 +127,58 @@ if(PY_SYS_SAGE)
     message(STATUS "Python site-packages directory: ${PYTHON_SITE}")
 
 endif()
-#else()
 
-    add_library(sys-sage SHARED ${SOURCES} ${HEADERS})
+######################################################
+#################### INSTALLATION ####################
+######################################################
 
-    # For Quantum Systems
-    if(QDMI)
-        target_link_libraries(sys-sage PUBLIC
-            backend_ibm
-            qdmi
-            qinfo
-        )
-    endif()
+install(
+    TARGETS sys-sage
+    EXPORT sys-sage-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
-    target_link_libraries(sys-sage PUBLIC LibXml2::LibXml2)
-    target_link_libraries(sys-sage PUBLIC nlohmann_json::nlohmann_json)
+install(
+    DIRECTORY .
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl"
+)
 
-    target_include_directories(sys-sage PUBLIC  
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>  
-        $<INSTALL_INTERFACE:inc>
-        $<INSTALL_INTERFACE:lib>
-    )
-    install(
-        TARGETS sys-sage
-        EXPORT sys-sage-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib/cmake/lib
-        ARCHIVE DESTINATION lib/cmake/lib
-    )
-    #for spack
-    install(
-        EXPORT sys-sage-targets
-        FILE sys-sage-targets.cmake
-        DESTINATION lib/cmake/sys-sage
-        NAMESPACE syssage::
-    )
-    install(DIRECTORY "."
-        DESTINATION lib/cmake/inc
-        FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
+install(
+    EXPORT sys-sage-targets
+    FILE sys-sage-targets.cmake
+    NAMESPACE sys-sage::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sys-sage
+)
 
-    install(
-        TARGETS sys-sage
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-    )
-    install(DIRECTORY "."
-        DESTINATION inc
-        FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
+######################################################
+###################### PACKAGING #####################
+######################################################
 
-#endif()
+include(CMakePackageConfigHelpers)
+
+# CMake
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/pkg/sys-sage-config.cmake.in
+    ${PROJECT_BINARY_DIR}/sys-sage-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sys-sage
+)
+
+install(
+    FILES ${PROJECT_BINARY_DIR}/sys-sage-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sys-sage
+)
+
+# pkg-config
+configure_file(
+    ${PROJECT_SOURCE_DIR}/pkg/sys-sage.pc.in
+    ${PROJECT_BINARY_DIR}/sys-sage.pc
+    @ONLY
+)
+
+install(
+    FILES ${PROJECT_BINARY_DIR}/sys-sage.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)


### PR DESCRIPTION
Here are some notes:

- I have tried to make the changes so that the git diff viewer is easy to read. I think I didn't succeed. Sometimes some reodering was needed, because you interleaved some thing that should otherwise be grouped together for clarity. I hope you bare with me. I strongly encourage you to also open the files directly without the diff viewer to see the structure.

- CMakeLists.txt:
    - I have removed the gcc compiler version check since I assumed you wanted to test whether it supports the C++20 standard. This is already handled for us when specifying the compiler options, i.e. `cxx_std_20`

    - I was able to move the declaration of the sys-sage library to the root CMakeLists.txt without using interfaces to be able to set the compiler options there

      -> we need to use `target_sources` in src/CMakeLists.txt

    - I have removed the explicit `cmake_policy(SET CMP0048 NEW)` call since it is already handled for us automatically:
      Because we have `cmake_minimum_required(VERSION 3.22)`, this will implicitely call `cmake_policy(VERSION 3.22)` as described in the docs (https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version).
      This will also set all policies prior to version 3.22 (including CMP0048) to NEW as described in the following sentence: "All policies known to the running version of CMake and introduced in the policy version or earlier will be set to use NEW behavior." (https://cmake.org/cmake/help/latest/command/cmake_policy.html#setting-policies-by-cmake-version)

      -> effectively, since policy CMP0048 was introduced in version 3.0, explicitly calling cmake_policy is redundant

    - I have moved the options before checking for the dependencies.
      For me it doesn't really make sense to use something like `if(NVIDIA_MIG)`
      before even declaring `NVIDIA_MIG` as an option.

    - install and configure_file commands were moved to src/CMakeLists.txt

    - for some reason, the `PY_SYS_SAGE` option is never defined

    - changed `include_directories`/`link_libraries` to `target_include_directories`/`target_link_libraries` to make them a PUBLIC dependency and moved them to src/CMakeLists.txt

    - moved `package_config_files` and `install` commands to src/CMakeLists.txt

- src/CMakeLists.txt:
    - moved the external interfaces out of the list of sources and instead applied an if-check to verify that the option was set

      -> I think this is more explicit and easier to reason about instead of relying on the internal header guard inside of the source files (I would then remove the header guards in the rework project structure PR)

      -> same reasoning applied to QDMI parser

    - header files are not compiled -> removed the HEADER list

    - right now, the python bindings are compiled in way such that each source file is compiled again, meaning that setting `-DPY_SYS_SAGE=on` will result in all files being compiled twice, one time for libsys-sage.so and another for the python bindings.
      This is because of the line: `pybind11_add_module(sys_sage MODULE ${PY_BINDS}/sys-sage-bindings.cpp ${SOURCES} ${HEADERS})`, where you again specify the SOURCES list.
      This essentially creates two completely independant versions of sys-sage. We already have talked about this

      -> the Python bindings shouldn't recompile everything and simply link against libsys-sage.so

    - removed second installation layer by updating lines 146 onwards

- examples/CMakeLists.txt:
    - made the link_libraries target-specific

    - I couldn't find an example that actually uses OpenMP -> removed it

    - lines 38-39: interleaved installation commands

      -> move them to the end end move the if-statements below up

- pkg/sys-sage.pc
    - In older CMake, one would use the CMAKE_INSTALL_PREFIX option at configuration time to set the installation destination. However, there is a relatively new flag --prefix for the command cmake --install build --prefix <prefix> which can override the value of CMAKE_INSTALL_PREFIX. It's a feature that allows for decoupling the configuration and installation process in CMake. I think it's a cool functionality. It can for instance be used to install the same version of sys-sage to multiple locations on the same system without having to compile everything again. The above changes simply allow for querying the correct paths in pkg-config independant from the CMAKE_INSTALL_PREFIX, so that it also works when using --prefix. Of course, one can still use CMAKE_INSTALL_PREFIX as usual and everything works just as before. It just also supports --prefix. The downside is that the path is kind of "ugly", since we use the ../... The paths when running `pkg-config --cflags sys-sage` and `pkg-config --libs sys-sage` are for instance `-I/home/mzarif/hiwi/sys-sage/install/lib/pkgconfig/../../include` and `-L/home/mzarif/hiwi/sys-sage/install/lib/pkgconfig/../../lib -lsys-sage` respectively. But I guess it's good enough.